### PR TITLE
Improve string expression validity checking

### DIFF
--- a/src/evaluator.cpp
+++ b/src/evaluator.cpp
@@ -67,6 +67,10 @@ bool Evaluator::evaluate(std::map<std::string, std::string> const& fields) {
 std::shared_ptr<node::TreeNode> Evaluator::parse_expression() {
     auto left_and_operation = parse_and_operation();
 
+    if (tokenizer_.has_token() && tokenizer_.token()->is_not(token::TokenType::OR)) {
+        return nullptr;
+    }
+
     while (tokenizer_.has_token() && tokenizer_.token()->is(token::TokenType::OR)) {
         auto or_operation = std::make_shared<node::TreeNode>(token::TokenType::OR);
         tokenizer_++;

--- a/tests/src/evaluator_test.cpp
+++ b/tests/src/evaluator_test.cpp
@@ -44,13 +44,24 @@ TEST_F(EvaluatorTest, EmptyExpression) {
     EXPECT_TRUE(evaluator.evaluate({}));
 }
 
-TEST_F(EvaluatorTest, InvalidExpression) {
+TEST_F(EvaluatorTest, MissingParenthesisExpression) {
     using namespace booleval;
 
-    std::string expression = "(field_a foo or field_b bar";
+    Evaluator evaluator;
+
+    std::string missing_parenthesis_expression = "(field_a foo or field_b bar";
+    EXPECT_FALSE(evaluator.build_expression_tree(missing_parenthesis_expression));
+    EXPECT_FALSE(evaluator.is_activated());
+    EXPECT_TRUE(evaluator.evaluate({}));
+}
+
+TEST_F(EvaluatorTest, MultipleFieldsExpression) {
+    using namespace booleval;
 
     Evaluator evaluator;
-    EXPECT_FALSE(evaluator.build_expression_tree(expression));
+
+    std::string multiple_fields_in_row_expression = "field_a foo field_b";
+    EXPECT_FALSE(evaluator.build_expression_tree(multiple_fields_in_row_expression));
     EXPECT_FALSE(evaluator.is_activated());
     EXPECT_TRUE(evaluator.evaluate({}));
 }


### PR DESCRIPTION
Improvement regarding the string expression validation.
Expressions that have multiple fields in a row, e.g. `src 127.0.0.1 dst`, are marked as invalid.