### PR TITLE
Fix unhandled std::bad_any_cast exception

### DIFF
--- a/include/booleval/utils/any_mem_fn.h
+++ b/include/booleval/utils/any_mem_fn.h
@@ -70,7 +70,11 @@ public:
 
     template <typename T>
     any_value invoke(T obj) {
-        return fn_(obj);
+        try {
+            return fn_(obj);
+        } catch (std::bad_any_cast const&) {
+            return {};
+        }
     }
 
 private:

--- a/tests/src/evaluator_test.cpp
+++ b/tests/src/evaluator_test.cpp
@@ -239,3 +239,18 @@ TEST_F(EvaluatorTest, MultipleOperators) {
     EXPECT_FALSE(evaluator.evaluate(baz));
     EXPECT_TRUE(evaluator.evaluate(qux));
 }
+
+TEST_F(EvaluatorTest, FieldsFromDifferentClasses) {
+    obj<std::string> foo{ "one" };
+    multi_obj<std::string, uint8_t> bar{ "two", 2 };
+
+    booleval::evaluator evaluator({
+        { "field_a", &obj<std::string>::value_a },
+        { "field_b", &multi_obj<std::string, uint8_t>::value_b }
+    });
+
+    EXPECT_TRUE(evaluator.expression("field_a one and field_b 2"));
+    EXPECT_TRUE(evaluator.is_activated());
+    EXPECT_FALSE(evaluator.evaluate(foo));
+    EXPECT_FALSE(evaluator.evaluate(bar));
+}


### PR DESCRIPTION
Fix std::bad_any_cast exception in case of fields defined by multiple classes.

Fix for #42 