### PR TITLE
Allow quote type to be specified when parsing expression

### DIFF
--- a/include/booleval/evaluator.hpp
+++ b/include/booleval/evaluator.hpp
@@ -35,6 +35,7 @@
 #include <booleval/utils/any_mem_fn.hpp>
 #include <booleval/tree/result_visitor.hpp>
 #include <booleval/tree/expression_tree.hpp>
+#include <booleval/utils/split_range.hpp>
 
 namespace booleval {
 
@@ -60,7 +61,7 @@ public:
     ~evaluator() = default;
 
     /**
-     * Checks whether the evaulation is activated or not, i.e.
+     * Checks whether the evaluation is activated or not, i.e.
      * if the expression tree is successfully built.
      *
      * @return True if the evaluation is activated, otherwise false
@@ -74,7 +75,7 @@ public:
      *
      * @return True if the expression is valid, otherwise false
      */
-    [[nodiscard]] bool expression(std::string_view expression);
+    [[nodiscard]] bool expression(std::string_view expression, char quote_char = utils::double_quote_char);
 
     /**
      * Evaluates expression tree for the object passed in.

--- a/include/booleval/token/tokenizer.hpp
+++ b/include/booleval/token/tokenizer.hpp
@@ -99,7 +99,7 @@ public:
     /**
      * Tokenizes the expression and transforms it into the collection of tokens.
      */
-    void tokenize();
+    void tokenize(char quote_char);
 
     /**
      * Clears the collection of tokens and sets the current index to zero.

--- a/include/booleval/tree/expression_tree.hpp
+++ b/include/booleval/tree/expression_tree.hpp
@@ -70,7 +70,7 @@ public:
      *
      * @return True if the expression tree is built successfully, otherwise false
      */
-    [[nodiscard]] bool build(std::string_view expression);
+    [[nodiscard]] bool build(std::string_view expression, char quote_char);
 
 private:
     /**

--- a/src/evaluator.cpp
+++ b/src/evaluator.cpp
@@ -32,10 +32,13 @@
 namespace booleval {
 
 evaluator::evaluator()
-    : is_activated_(false)
+    : is_activated_(false),
+      result_visitor_(),
+      expression_tree_()
 {}
 
-evaluator::evaluator(field_map const& fields) {
+evaluator::evaluator(field_map const& fields)
+    : evaluator() {
     result_visitor_.fields(fields);
 }
 
@@ -43,14 +46,14 @@ bool evaluator::is_activated() const noexcept {
     return is_activated_;
 }
 
-bool evaluator::expression(std::string_view expression) {
+bool evaluator::expression(std::string_view expression, char quote_char) {
     is_activated_ = false;
 
     if (expression.empty()) {
         return true;
     }
 
-    if (expression_tree_.build(expression)) {
+    if (expression_tree_.build(expression, quote_char)) {
         is_activated_ = true;
     }
 

--- a/src/token/tokenizer.cpp
+++ b/src/token/tokenizer.cpp
@@ -64,7 +64,7 @@ token const& tokenizer::weak_next_token() {
     return tokens_.at(current_token_index_);
 }
 
-void tokenizer::tokenize() {
+void tokenizer::tokenize(char quote_char) {
     tokens_.clear();
     reset();
 
@@ -75,7 +75,7 @@ void tokenizer::tokenize() {
         utils::split_options::allow_quoted_strings;
 
     auto delims = utils::join(std::begin(single_char_symbols), std::end(single_char_symbols));
-    auto tokens_range = utils::split_range<options>(expression_, delims);
+    auto tokens_range = utils::split_range<options>(expression_, delims, quote_char);
 
     for (auto const& [quoted, index, value] : tokens_range) {
         auto type = quoted ? token_type::field : map_to_token_type(value);

--- a/src/tree/expression_tree.cpp
+++ b/src/tree/expression_tree.cpp
@@ -42,10 +42,10 @@ std::shared_ptr<tree::tree_node> expression_tree::root() noexcept {
     return root_;
 }
 
-bool expression_tree::build(std::string_view expression) {
+bool expression_tree::build(std::string_view expression, char quote_char) {
     tokenizer_.reset();
     tokenizer_.expression(expression);
-    tokenizer_.tokenize();
+    tokenizer_.tokenize(quote_char);
 
     root_ = parse_expression();
     if (nullptr == root_) {


### PR DESCRIPTION
Hi Marin,

Please have a look at the changes which allow the quote delimiter to be optionally specified when calling evaluator::expression(). This is still defaulted to use double quotes so it won't break any existing code.

I also fixed the evaluator constructors to fully initialise the data members. Specifically, is_activated_ wasn't getting set when evaluator(field_map const& fields) constructor was used.

Cheers

James